### PR TITLE
Convert tabs to 4 spaces

### DIFF
--- a/library/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/library/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -39,16 +39,16 @@ import android.widget.OverScroller;
 import android.widget.Scroller;
 
 public class TouchImageView extends ImageView {
-	
-	private static final String DEBUG = "DEBUG";
-	
-	//
-	// SuperMin and SuperMax multipliers. Determine how much the image can be
-	// zoomed below or above the zoom boundaries, before animating back to the
-	// min/max zoom boundary.
-	//
-	private static final float SUPER_MIN_MULTIPLIER = .75f;
-	private static final float SUPER_MAX_MULTIPLIER = 1.25f;
+
+    private static final String DEBUG = "DEBUG";
+
+    //
+    // SuperMin and SuperMax multipliers. Determine how much the image can be
+    // zoomed below or above the zoom boundaries, before animating back to the
+    // min/max zoom boundary.
+    //
+    private static final float SUPER_MIN_MULTIPLIER = .75f;
+    private static final float SUPER_MAX_MULTIPLIER = 1.25f;
 
     //
     // Scale of image ranges from minScale to maxScale, where minScale == 1
@@ -61,7 +61,7 @@ public class TouchImageView extends ImageView {
     // MTRANS_X and MTRANS_Y are the other values used. prevMatrix is the matrix
     // saved prior to the screen rotating.
     //
-	private Matrix matrix, prevMatrix;
+    private Matrix matrix, prevMatrix;
 
     private static enum State { NONE, DRAG, ZOOM, FLING, ANIMATE_ZOOM };
     private State state;
@@ -125,7 +125,7 @@ public class TouchImageView extends ImageView {
         m = new float[9];
         normalizedScale = 1;
         if (mScaleType == null) {
-        	mScaleType = ScaleType.FIT_CENTER;
+            mScaleType = ScaleType.FIT_CENTER;
         }
 
         minScale = 1;
@@ -149,7 +149,7 @@ public class TouchImageView extends ImageView {
     }
 
     public void setOnTouchImageViewListener(OnTouchImageViewListener l) {
-    	touchImageViewListener = l;
+        touchImageViewListener = l;
     }
 
     public void setOnDoubleTapListener(GestureDetector.OnDoubleTapListener l) {
@@ -159,55 +159,54 @@ public class TouchImageView extends ImageView {
     @Override
     public void setImageResource(int resId) {
         imageRenderedAtLeastOnce = false;
-    	super.setImageResource(resId);
-    	savePreviousImageValues();
-    	fitImageToView();
+        super.setImageResource(resId);
+        savePreviousImageValues();
+        fitImageToView();
     }
     
     @Override
     public void setImageBitmap(Bitmap bm) {
         imageRenderedAtLeastOnce = false;
-    	super.setImageBitmap(bm);
-    	savePreviousImageValues();
-    	fitImageToView();
+        super.setImageBitmap(bm);
+        savePreviousImageValues();
+        fitImageToView();
     }
     
     @Override
     public void setImageDrawable(Drawable drawable) {
         imageRenderedAtLeastOnce = false;
-    	super.setImageDrawable(drawable);
-    	savePreviousImageValues();
-    	fitImageToView();
+        super.setImageDrawable(drawable);
+        savePreviousImageValues();
+        fitImageToView();
     }
     
     @Override
     public void setImageURI(Uri uri) {
         imageRenderedAtLeastOnce = false;
-    	super.setImageURI(uri);
-    	savePreviousImageValues();
-    	fitImageToView();
+        super.setImageURI(uri);
+        savePreviousImageValues();
+        fitImageToView();
     }
     
     @Override
     public void setScaleType(ScaleType type) {
-    	if (type == ScaleType.MATRIX) {
-    		super.setScaleType(ScaleType.MATRIX);
-    		
-    	} else {
-    		mScaleType = type;
-    		if (onDrawReady) {
+        if (type == ScaleType.MATRIX) {
+            super.setScaleType(ScaleType.MATRIX);
+        } else {
+            mScaleType = type;
+            if (onDrawReady) {
                 //
-    			// If the image is already rendered, scaleType has been called programmatically
-    			// and the TouchImageView should be updated with the new scaleType.
+                // If the image is already rendered, scaleType has been called programmatically
+                // and the TouchImageView should be updated with the new scaleType.
                 //
-    			setZoom(this);
-    		}
-    	}
+                setZoom(this);
+            }
+        }
     }
     
     @Override
     public ScaleType getScaleType() {
-    	return mScaleType;
+        return mScaleType;
     }
     
     /**
@@ -215,7 +214,7 @@ public class TouchImageView extends ImageView {
      * @return true if image is zoomed
      */
     public boolean isZoomed() {
-    	return normalizedScale != 1;
+        return normalizedScale != 1;
     }
     
     /**
@@ -223,15 +222,15 @@ public class TouchImageView extends ImageView {
      * @return rect representing zoomed image
      */
     public RectF getZoomedRect() {
-    	if (mScaleType == ScaleType.FIT_XY) {
-    		throw new UnsupportedOperationException("getZoomedRect() not supported with FIT_XY");
-    	}
-    	PointF topLeft = transformCoordTouchToBitmap(0, 0, true);
-    	PointF bottomRight = transformCoordTouchToBitmap(viewWidth, viewHeight, true);
-    	
-    	float w = getDrawable().getIntrinsicWidth();
-    	float h = getDrawable().getIntrinsicHeight();
-    	return new RectF(topLeft.x / w, topLeft.y / h, bottomRight.x / w, bottomRight.y / h);
+        if (mScaleType == ScaleType.FIT_XY) {
+            throw new UnsupportedOperationException("getZoomedRect() not supported with FIT_XY");
+        }
+        PointF topLeft = transformCoordTouchToBitmap(0, 0, true);
+        PointF bottomRight = transformCoordTouchToBitmap(viewWidth, viewHeight, true);
+
+        float w = getDrawable().getIntrinsicWidth();
+        float h = getDrawable().getIntrinsicHeight();
+        return new RectF(topLeft.x / w, topLeft.y / h, bottomRight.x / w, bottomRight.y / h);
     }
     
     /**
@@ -239,65 +238,65 @@ public class TouchImageView extends ImageView {
      * in the prevMatrix and prevView variables.
      */
     public void savePreviousImageValues() {
-    	if (matrix != null && viewHeight != 0 && viewWidth != 0) {
-	    	matrix.getValues(m);
-	    	prevMatrix.setValues(m);
-	    	prevMatchViewHeight = matchViewHeight;
-	        prevMatchViewWidth = matchViewWidth;
-	        prevViewHeight = viewHeight;
-	        prevViewWidth = viewWidth;
-    	}
+        if (matrix != null && viewHeight != 0 && viewWidth != 0) {
+            matrix.getValues(m);
+            prevMatrix.setValues(m);
+            prevMatchViewHeight = matchViewHeight;
+            prevMatchViewWidth = matchViewWidth;
+            prevViewHeight = viewHeight;
+            prevViewWidth = viewWidth;
+        }
     }
     
     @Override
     public Parcelable onSaveInstanceState() {
-    	Bundle bundle = new Bundle();
-    	bundle.putParcelable("instanceState", super.onSaveInstanceState());
-    	bundle.putFloat("saveScale", normalizedScale);
-    	bundle.putFloat("matchViewHeight", matchViewHeight);
-    	bundle.putFloat("matchViewWidth", matchViewWidth);
-    	bundle.putInt("viewWidth", viewWidth);
-    	bundle.putInt("viewHeight", viewHeight);
-    	matrix.getValues(m);
-    	bundle.putFloatArray("matrix", m);
-    	bundle.putBoolean("imageRendered", imageRenderedAtLeastOnce);
-    	return bundle;
+        Bundle bundle = new Bundle();
+        bundle.putParcelable("instanceState", super.onSaveInstanceState());
+        bundle.putFloat("saveScale", normalizedScale);
+        bundle.putFloat("matchViewHeight", matchViewHeight);
+        bundle.putFloat("matchViewWidth", matchViewWidth);
+        bundle.putInt("viewWidth", viewWidth);
+        bundle.putInt("viewHeight", viewHeight);
+        matrix.getValues(m);
+        bundle.putFloatArray("matrix", m);
+        bundle.putBoolean("imageRendered", imageRenderedAtLeastOnce);
+        return bundle;
     }
     
     @Override
     public void onRestoreInstanceState(Parcelable state) {
-      	if (state instanceof Bundle) {
-	        Bundle bundle = (Bundle) state;
-	        normalizedScale = bundle.getFloat("saveScale");
-	        m = bundle.getFloatArray("matrix");
-	        prevMatrix.setValues(m);
-	        prevMatchViewHeight = bundle.getFloat("matchViewHeight");
-	        prevMatchViewWidth = bundle.getFloat("matchViewWidth");
-	        prevViewHeight = bundle.getInt("viewHeight");
-	        prevViewWidth = bundle.getInt("viewWidth");
-	        imageRenderedAtLeastOnce = bundle.getBoolean("imageRendered");
-	        super.onRestoreInstanceState(bundle.getParcelable("instanceState"));
-	        return;
-      	}
+          if (state instanceof Bundle) {
+            Bundle bundle = (Bundle) state;
+            normalizedScale = bundle.getFloat("saveScale");
+            m = bundle.getFloatArray("matrix");
+            prevMatrix.setValues(m);
+            prevMatchViewHeight = bundle.getFloat("matchViewHeight");
+            prevMatchViewWidth = bundle.getFloat("matchViewWidth");
+            prevViewHeight = bundle.getInt("viewHeight");
+            prevViewWidth = bundle.getInt("viewWidth");
+            imageRenderedAtLeastOnce = bundle.getBoolean("imageRendered");
+            super.onRestoreInstanceState(bundle.getParcelable("instanceState"));
+            return;
+          }
 
-      	super.onRestoreInstanceState(state);
+          super.onRestoreInstanceState(state);
     }
     
     @Override
     protected void onDraw(Canvas canvas) {
-    	onDrawReady = true;
-    	imageRenderedAtLeastOnce = true;
-    	if (delayedZoomVariables != null) {
-    		setZoom(delayedZoomVariables.scale, delayedZoomVariables.focusX, delayedZoomVariables.focusY, delayedZoomVariables.scaleType);
-    		delayedZoomVariables = null;
-    	}
-    	super.onDraw(canvas);
+        onDrawReady = true;
+        imageRenderedAtLeastOnce = true;
+        if (delayedZoomVariables != null) {
+            setZoom(delayedZoomVariables.scale, delayedZoomVariables.focusX, delayedZoomVariables.focusY, delayedZoomVariables.scaleType);
+            delayedZoomVariables = null;
+        }
+        super.onDraw(canvas);
     }
     
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
-    	super.onConfigurationChanged(newConfig);
-    	savePreviousImageValues();
+        super.onConfigurationChanged(newConfig);
+        savePreviousImageValues();
     }
     
     /**
@@ -305,7 +304,7 @@ public class TouchImageView extends ImageView {
      * @return max zoom multiplier.
      */
     public float getMaxZoom() {
-    	return maxScale;
+        return maxScale;
     }
 
     /**
@@ -322,7 +321,7 @@ public class TouchImageView extends ImageView {
      * @return min zoom multiplier.
      */
     public float getMinZoom() {
-    	return minScale;
+        return minScale;
     }
     
     /**
@@ -331,7 +330,7 @@ public class TouchImageView extends ImageView {
      * @return current zoom multiplier.
      */
     public float getCurrentZoom() {
-    	return normalizedScale;
+        return normalizedScale;
     }
     
     /**
@@ -339,16 +338,16 @@ public class TouchImageView extends ImageView {
      * @param min min zoom multiplier.
      */
     public void setMinZoom(float min) {
-    	minScale = min;
-    	superMinScale = SUPER_MIN_MULTIPLIER * minScale;
+        minScale = min;
+        superMinScale = SUPER_MIN_MULTIPLIER * minScale;
     }
     
     /**
      * Reset zoom and translation to initial state.
      */
     public void resetZoom() {
-    	normalizedScale = 1;
-    	fitImageToView();
+        normalizedScale = 1;
+        fitImageToView();
     }
     
     /**
@@ -356,7 +355,7 @@ public class TouchImageView extends ImageView {
      * @param scale
      */
     public void setZoom(float scale) {
-    	setZoom(scale, 0.5f, 0.5f);
+        setZoom(scale, 0.5f, 0.5f);
     }
     
     /**
@@ -369,7 +368,7 @@ public class TouchImageView extends ImageView {
      * @param focusY
      */
     public void setZoom(float scale, float focusX, float focusY) {
-    	setZoom(scale, focusX, focusY, mScaleType);
+        setZoom(scale, focusX, focusY, mScaleType);
     }
     
     /**
@@ -383,27 +382,27 @@ public class TouchImageView extends ImageView {
      * @param scaleType
      */
     public void setZoom(float scale, float focusX, float focusY, ScaleType scaleType) {
-    	//
-    	// setZoom can be called before the image is on the screen, but at this point, 
-    	// image and view sizes have not yet been calculated in onMeasure. Thus, we should
-    	// delay calling setZoom until the view has been measured.
-    	//
-    	if (!onDrawReady) {
-    		delayedZoomVariables = new ZoomVariables(scale, focusX, focusY, scaleType);
-    		return;
-    	}
-    	
-    	if (scaleType != mScaleType) {
-    		setScaleType(scaleType);
-    	}
-    	resetZoom();
-    	scaleImage(scale, viewWidth / 2, viewHeight / 2, true);
-    	matrix.getValues(m);
-    	m[Matrix.MTRANS_X] = -((focusX * getImageWidth()) - (viewWidth * 0.5f));
-    	m[Matrix.MTRANS_Y] = -((focusY * getImageHeight()) - (viewHeight * 0.5f));
-    	matrix.setValues(m);
-    	fixTrans();
-    	setImageMatrix(matrix);
+        //
+        // setZoom can be called before the image is on the screen, but at this point,
+        // image and view sizes have not yet been calculated in onMeasure. Thus, we should
+        // delay calling setZoom until the view has been measured.
+        //
+        if (!onDrawReady) {
+            delayedZoomVariables = new ZoomVariables(scale, focusX, focusY, scaleType);
+            return;
+        }
+
+        if (scaleType != mScaleType) {
+            setScaleType(scaleType);
+        }
+        resetZoom();
+        scaleImage(scale, viewWidth / 2, viewHeight / 2, true);
+        matrix.getValues(m);
+        m[Matrix.MTRANS_X] = -((focusX * getImageWidth()) - (viewWidth * 0.5f));
+        m[Matrix.MTRANS_Y] = -((focusY * getImageHeight()) - (viewHeight * 0.5f));
+        matrix.setValues(m);
+        fixTrans();
+        setImageMatrix(matrix);
     }
     
     /**
@@ -412,8 +411,8 @@ public class TouchImageView extends ImageView {
      * @param img
      */
     public void setZoom(TouchImageView img) {
-    	PointF center = img.getScrollPosition();
-    	setZoom(img.getCurrentZoom(), center.x, center.y, img.getScaleType());
+        PointF center = img.getScrollPosition();
+        setZoom(img.getCurrentZoom(), center.x, center.y, img.getScaleType());
     }
     
     /**
@@ -424,11 +423,11 @@ public class TouchImageView extends ImageView {
      * @return PointF representing the scroll position of the zoomed image.
      */
     public PointF getScrollPosition() {
-    	Drawable drawable = getDrawable();
-    	if (drawable == null) {
-    		return null;
-    	}
-    	int drawableWidth = drawable.getIntrinsicWidth();
+        Drawable drawable = getDrawable();
+        if (drawable == null) {
+            return null;
+        }
+        int drawableWidth = drawable.getIntrinsicWidth();
         int drawableHeight = drawable.getIntrinsicHeight();
         
         PointF point = transformCoordTouchToBitmap(viewWidth / 2, viewHeight / 2, true);
@@ -444,7 +443,7 @@ public class TouchImageView extends ImageView {
      * @param focusY
      */
     public void setScrollPosition(float focusX, float focusY) {
-    	setZoom(normalizedScale, focusX, focusY);
+        setZoom(normalizedScale, focusX, focusY);
     }
     
     /**
@@ -472,16 +471,16 @@ public class TouchImageView extends ImageView {
      * then makes sure the image is centered correctly within the view.
      */
     private void fixScaleTrans() {
-    	fixTrans();
-    	matrix.getValues(m);
-    	if (getImageWidth() < viewWidth) {
-    		m[Matrix.MTRANS_X] = (viewWidth - getImageWidth()) / 2;
-    	}
-    	
-    	if (getImageHeight() < viewHeight) {
-    		m[Matrix.MTRANS_Y] = (viewHeight - getImageHeight()) / 2;
-    	}
-    	matrix.setValues(m);
+        fixTrans();
+        matrix.getValues(m);
+        if (getImageWidth() < viewWidth) {
+            m[Matrix.MTRANS_X] = (viewWidth - getImageWidth()) / 2;
+        }
+        
+        if (getImageHeight() < viewHeight) {
+            m[Matrix.MTRANS_Y] = (viewHeight - getImageHeight()) / 2;
+        }
+        matrix.setValues(m);
     }
 
     private float getFixTrans(float trans, float viewSize, float contentSize) {
@@ -511,19 +510,19 @@ public class TouchImageView extends ImageView {
     }
     
     private float getImageWidth() {
-    	return matchViewWidth * normalizedScale;
+        return matchViewWidth * normalizedScale;
     }
     
     private float getImageHeight() {
-    	return matchViewHeight * normalizedScale;
+        return matchViewHeight * normalizedScale;
     }
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         Drawable drawable = getDrawable();
         if (drawable == null || drawable.getIntrinsicWidth() == 0 || drawable.getIntrinsicHeight() == 0) {
-        	setMeasuredDimension(0, 0);
-        	return;
+            setMeasuredDimension(0, 0);
+            return;
         }
         
         int drawableWidth = drawable.getIntrinsicWidth();
@@ -556,45 +555,45 @@ public class TouchImageView extends ImageView {
      * allows the image to maintain its zoom after rotation.
      */
     private void fitImageToView() {
-    	Drawable drawable = getDrawable();
+        Drawable drawable = getDrawable();
         if (drawable == null || drawable.getIntrinsicWidth() == 0 || drawable.getIntrinsicHeight() == 0) {
-        	return;
+            return;
         }
         if (matrix == null || prevMatrix == null) {
-        	return;
+            return;
         }
         
         int drawableWidth = drawable.getIntrinsicWidth();
         int drawableHeight = drawable.getIntrinsicHeight();
-    	
-    	//
-    	// Scale image for view
-    	//
+        
+        //
+        // Scale image for view
+        //
         float scaleX = (float) viewWidth / drawableWidth;
         float scaleY = (float) viewHeight / drawableHeight;
         
         switch (mScaleType) {
         case CENTER:
-        	scaleX = scaleY = 1;
-        	break;
-        	
+            scaleX = scaleY = 1;
+            break;
+            
         case CENTER_CROP:
-        	scaleX = scaleY = Math.max(scaleX, scaleY);
-        	break;
-        	
+            scaleX = scaleY = Math.max(scaleX, scaleY);
+            break;
+            
         case CENTER_INSIDE:
-        	scaleX = scaleY = Math.min(1, Math.min(scaleX, scaleY));
-        	
+            scaleX = scaleY = Math.min(1, Math.min(scaleX, scaleY));
+            
         case FIT_CENTER:
         case FIT_START:
         case FIT_END:
-        	scaleX = scaleY = Math.min(scaleX, scaleY);
-        	break;
-        	
+            scaleX = scaleY = Math.min(scaleX, scaleY);
+            break;
+            
         case FIT_XY:
-        	break;
-        	
-    	default:
+            break;
+            
+        default:
         }
 
         //
@@ -605,43 +604,43 @@ public class TouchImageView extends ImageView {
         matchViewWidth = viewWidth - redundantXSpace;
         matchViewHeight = viewHeight - redundantYSpace;
         if (!isZoomed() && !imageRenderedAtLeastOnce) {
-        	//
-        	// Stretch and center image to fit view
-        	//
-        	matrix.setScale(scaleX, scaleY);
-        	switch (mScaleType) {
-        	case FIT_START:
-        		matrix.postTranslate(0, 0);
-        		break;
-        	case FIT_END:
-        		matrix.postTranslate(redundantXSpace, redundantYSpace);
-        		break;
-        	default:
-        		matrix.postTranslate(redundantXSpace / 2, redundantYSpace / 2);
-        	}
-        	normalizedScale = 1;
-        	
+            //
+            // Stretch and center image to fit view
+            //
+            matrix.setScale(scaleX, scaleY);
+            switch (mScaleType) {
+            case FIT_START:
+                matrix.postTranslate(0, 0);
+                break;
+            case FIT_END:
+                matrix.postTranslate(redundantXSpace, redundantYSpace);
+                break;
+            default:
+                matrix.postTranslate(redundantXSpace / 2, redundantYSpace / 2);
+            }
+            normalizedScale = 1;
+            
         } else {
-        	//
-        	// These values should never be 0 or we will set viewWidth and viewHeight
-        	// to NaN in translateMatrixAfterRotate. To avoid this, call savePreviousImageValues
-        	// to set them equal to the current values.
-        	//
-//        	if (prevMatchViewWidth == 0 || prevMatchViewHeight == 0) {
-        		savePreviousImageValues();
-//        	}
-        	
-        	prevMatrix.getValues(m);
-        	
-        	//
-        	// Rescale Matrix after rotation
-        	//
-        	m[Matrix.MSCALE_X] = matchViewWidth / drawableWidth * normalizedScale;
-        	m[Matrix.MSCALE_Y] = matchViewHeight / drawableHeight * normalizedScale;
-        	
-        	//
-        	// TransX and TransY from previous matrix
-        	//
+            //
+            // These values should never be 0 or we will set viewWidth and viewHeight
+            // to NaN in translateMatrixAfterRotate. To avoid this, call savePreviousImageValues
+            // to set them equal to the current values.
+            //
+//            if (prevMatchViewWidth == 0 || prevMatchViewHeight == 0) {
+                savePreviousImageValues();
+//            }
+            
+            prevMatrix.getValues(m);
+            
+            //
+            // Rescale Matrix after rotation
+            //
+            m[Matrix.MSCALE_X] = matchViewWidth / drawableWidth * normalizedScale;
+            m[Matrix.MSCALE_Y] = matchViewHeight / drawableHeight * normalizedScale;
+            
+            //
+            // TransX and TransY from previous matrix
+            //
             float transX = m[Matrix.MTRANS_X];
             float transY = m[Matrix.MTRANS_Y];
 
@@ -677,25 +676,25 @@ public class TouchImageView extends ImageView {
      * @return
      */
     private int setViewSize(int mode, int size, int drawableWidth) {
-    	int viewSize;
-    	switch (mode) {
-		case MeasureSpec.EXACTLY:
-			viewSize = size;
-			break;
-			
-		case MeasureSpec.AT_MOST:
-			viewSize = Math.min(drawableWidth, size);
-			break;
-			
-		case MeasureSpec.UNSPECIFIED:
-			viewSize = drawableWidth;
-			break;
-			
-		default:
-			viewSize = size;
-		 	break;
-		}
-    	return viewSize;
+        int viewSize;
+        switch (mode) {
+        case MeasureSpec.EXACTLY:
+            viewSize = size;
+            break;
+            
+        case MeasureSpec.AT_MOST:
+            viewSize = Math.min(drawableWidth, size);
+            break;
+            
+        case MeasureSpec.UNSPECIFIED:
+            viewSize = drawableWidth;
+            break;
+            
+        default:
+            viewSize = size;
+             break;
+        }
+        return viewSize;
     }
     
     /**
@@ -711,31 +710,31 @@ public class TouchImageView extends ImageView {
      * @param drawableSize width/height of drawable
      */
     private void translateMatrixAfterRotate(int axis, float trans, float prevImageSize, float imageSize, int prevViewSize, int viewSize, int drawableSize) {
-    	if (imageSize < viewSize) {
-        	//
-        	// The width/height of image is less than the view's width/height. Center it.
-        	//
-        	m[axis] = (viewSize - (drawableSize * m[Matrix.MSCALE_X])) * 0.5f;
-        	
+        if (imageSize < viewSize) {
+            //
+            // The width/height of image is less than the view's width/height. Center it.
+            //
+            m[axis] = (viewSize - (drawableSize * m[Matrix.MSCALE_X])) * 0.5f;
+            
         } else if (trans > 0) {
-        	//
-        	// The image is larger than the view, but was not before rotation. Center it.
-        	//
-        	m[axis] = -((imageSize - viewSize) * 0.5f);
-        	
+            //
+            // The image is larger than the view, but was not before rotation. Center it.
+            //
+            m[axis] = -((imageSize - viewSize) * 0.5f);
+            
         } else {
-        	//
-        	// Find the area of the image which was previously centered in the view. Determine its distance
-        	// from the left/top side of the view as a fraction of the entire image's width/height. Use that percentage
-        	// to calculate the trans in the new view width/height.
-        	//
-        	float percentage = (Math.abs(trans) + (0.5f * prevViewSize)) / prevImageSize;
-        	m[axis] = -((percentage * imageSize) - (viewSize * 0.5f));
+            //
+            // Find the area of the image which was previously centered in the view. Determine its distance
+            // from the left/top side of the view as a fraction of the entire image's width/height. Use that percentage
+            // to calculate the trans in the new view width/height.
+            //
+            float percentage = (Math.abs(trans) + (0.5f * prevViewSize)) / prevImageSize;
+            m[axis] = -((percentage * imageSize) - (viewSize * 0.5f));
         }
     }
     
     private void setState(State state) {
-    	this.state = state;
+        this.state = state;
     }
     
     public boolean canScrollHorizontallyFroyo(int direction) {
@@ -744,38 +743,38 @@ public class TouchImageView extends ImageView {
     
     @Override
     public boolean canScrollHorizontally(int direction) {
-    	matrix.getValues(m);
-    	float x = m[Matrix.MTRANS_X];
-    	
-    	if (getImageWidth() < viewWidth) {
-    		return false;
-    		
-    	} else if (x >= -1 && direction < 0) {
-    		return false;
-    		
-    	} else if (Math.abs(x) + viewWidth + 1 >= getImageWidth() && direction > 0) {
-    		return false;
-    	}
-    	
-    	return true;
+        matrix.getValues(m);
+        float x = m[Matrix.MTRANS_X];
+        
+        if (getImageWidth() < viewWidth) {
+            return false;
+            
+        } else if (x >= -1 && direction < 0) {
+            return false;
+            
+        } else if (Math.abs(x) + viewWidth + 1 >= getImageWidth() && direction > 0) {
+            return false;
+        }
+        
+        return true;
     }
-		
+        
     @Override
     public boolean canScrollVertically(int direction) {
-    	matrix.getValues(m);
-    	float y = m[Matrix.MTRANS_Y];
+        matrix.getValues(m);
+        float y = m[Matrix.MTRANS_Y];
 
-    	if (getImageHeight() < viewHeight) {
-    		return false;
+        if (getImageHeight() < viewHeight) {
+            return false;
 
-    	} else if (y >= -1 && direction < 0) {
-    		return false;
+        } else if (y >= -1 && direction < 0) {
+            return false;
 
-    	} else if (Math.abs(y) + viewHeight + 1 >= getImageHeight() && direction > 0) {
-    		return false;
-    	}
+        } else if (Math.abs(y) + viewHeight + 1 >= getImageHeight() && direction > 0) {
+            return false;
+        }
 
-    	return true;
+        return true;
     }
     
     /**
@@ -785,63 +784,63 @@ public class TouchImageView extends ImageView {
      *
      */
     private class GestureListener extends GestureDetector.SimpleOnGestureListener {
-    	
+        
         @Override
         public boolean onSingleTapConfirmed(MotionEvent e)
         {
             if(doubleTapListener != null) {
-            	return doubleTapListener.onSingleTapConfirmed(e);
+                return doubleTapListener.onSingleTapConfirmed(e);
             }
-        	return performClick();
+            return performClick();
         }
         
         @Override
         public void onLongPress(MotionEvent e)
         {
-        	performLongClick();
+            performLongClick();
         }
         
         @Override
         public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY)
         {
-        	if (fling != null) {
-        		//
-        		// If a previous fling is still active, it should be cancelled so that two flings
-        		// are not run simultaenously.
-        		//
-        		fling.cancelFling();
-        	}
-        	fling = new Fling((int) velocityX, (int) velocityY);
-        	compatPostOnAnimation(fling);
-        	return super.onFling(e1, e2, velocityX, velocityY);
+            if (fling != null) {
+                //
+                // If a previous fling is still active, it should be cancelled so that two flings
+                // are not run simultaenously.
+                //
+                fling.cancelFling();
+            }
+            fling = new Fling((int) velocityX, (int) velocityY);
+            compatPostOnAnimation(fling);
+            return super.onFling(e1, e2, velocityX, velocityY);
         }
         
         @Override
         public boolean onDoubleTap(MotionEvent e) {
-        	boolean consumed = false;
+            boolean consumed = false;
             if(doubleTapListener != null) {
-            	consumed = doubleTapListener.onDoubleTap(e);
+                consumed = doubleTapListener.onDoubleTap(e);
             }
-        	if (state == State.NONE) {
-	        	float targetZoom = (normalizedScale == minScale) ? maxScale : minScale;
-	        	DoubleTapZoom doubleTap = new DoubleTapZoom(targetZoom, e.getX(), e.getY(), false);
-	        	compatPostOnAnimation(doubleTap);
-	        	consumed = true;
-        	}
-        	return consumed;
+            if (state == State.NONE) {
+                float targetZoom = (normalizedScale == minScale) ? maxScale : minScale;
+                DoubleTapZoom doubleTap = new DoubleTapZoom(targetZoom, e.getX(), e.getY(), false);
+                compatPostOnAnimation(doubleTap);
+                consumed = true;
+            }
+            return consumed;
         }
 
         @Override
         public boolean onDoubleTapEvent(MotionEvent e) {
             if(doubleTapListener != null) {
-            	return doubleTapListener.onDoubleTapEvent(e);
+                return doubleTapListener.onDoubleTapEvent(e);
             }
             return false;
         }
     }
     
     public interface OnTouchImageViewListener {
-    	public void onMove();
+        public void onMove();
     }
     
     /**
@@ -851,62 +850,62 @@ public class TouchImageView extends ImageView {
      *
      */
     private class PrivateOnTouchListener implements OnTouchListener {
-    	
-    	//
+        
+        //
         // Remember last point position for dragging
         //
         private PointF last = new PointF();
-    	
-    	@Override
+        
+        @Override
         public boolean onTouch(View v, MotionEvent event) {
             mScaleDetector.onTouchEvent(event);
             mGestureDetector.onTouchEvent(event);
             PointF curr = new PointF(event.getX(), event.getY());
             
             if (state == State.NONE || state == State.DRAG || state == State.FLING) {
-	            switch (event.getAction()) {
-	                case MotionEvent.ACTION_DOWN:
-	                	last.set(curr);
-	                    if (fling != null)
-	                    	fling.cancelFling();
-	                    setState(State.DRAG);
-	                    break;
-	                    
-	                case MotionEvent.ACTION_MOVE:
-	                    if (state == State.DRAG) {
-	                        float deltaX = curr.x - last.x;
-	                        float deltaY = curr.y - last.y;
-	                        float fixTransX = getFixDragTrans(deltaX, viewWidth, getImageWidth());
-	                        float fixTransY = getFixDragTrans(deltaY, viewHeight, getImageHeight());
-	                        matrix.postTranslate(fixTransX, fixTransY);
-	                        fixTrans();
-	                        last.set(curr.x, curr.y);
-	                    }
-	                    break;
-	
-	                case MotionEvent.ACTION_UP:
-	                case MotionEvent.ACTION_POINTER_UP:
-	                    setState(State.NONE);
-	                    break;
-	            }
+                switch (event.getAction()) {
+                    case MotionEvent.ACTION_DOWN:
+                        last.set(curr);
+                        if (fling != null)
+                            fling.cancelFling();
+                        setState(State.DRAG);
+                        break;
+                        
+                    case MotionEvent.ACTION_MOVE:
+                        if (state == State.DRAG) {
+                            float deltaX = curr.x - last.x;
+                            float deltaY = curr.y - last.y;
+                            float fixTransX = getFixDragTrans(deltaX, viewWidth, getImageWidth());
+                            float fixTransY = getFixDragTrans(deltaY, viewHeight, getImageHeight());
+                            matrix.postTranslate(fixTransX, fixTransY);
+                            fixTrans();
+                            last.set(curr.x, curr.y);
+                        }
+                        break;
+    
+                    case MotionEvent.ACTION_UP:
+                    case MotionEvent.ACTION_POINTER_UP:
+                        setState(State.NONE);
+                        break;
+                }
             }
             
             setImageMatrix(matrix);
             
             //
-    		// User-defined OnTouchListener
-    		//
-    		if(userTouchListener != null) {
-    			userTouchListener.onTouch(v, event);
-    		}
+            // User-defined OnTouchListener
+            //
+            if(userTouchListener != null) {
+                userTouchListener.onTouch(v, event);
+            }
             
-    		//
-    		// OnTouchImageViewListener is set: TouchImageView dragged by user.
-    		//
-    		if (touchImageViewListener != null) {
-    			touchImageViewListener.onMove();
-    		}
-    		
+            //
+            // OnTouchImageViewListener is set: TouchImageView dragged by user.
+            //
+            if (touchImageViewListener != null) {
+                touchImageViewListener.onMove();
+            }
+            
             //
             // indicate event was handled
             //
@@ -928,51 +927,51 @@ public class TouchImageView extends ImageView {
 
         @Override
         public boolean onScale(ScaleGestureDetector detector) {
-        	scaleImage(detector.getScaleFactor(), detector.getFocusX(), detector.getFocusY(), true);
-        	
-        	//
-        	// OnTouchImageViewListener is set: TouchImageView pinch zoomed by user.
-        	//
-        	if (touchImageViewListener != null) {
-        		touchImageViewListener.onMove();
-        	}
+            scaleImage(detector.getScaleFactor(), detector.getFocusX(), detector.getFocusY(), true);
+            
+            //
+            // OnTouchImageViewListener is set: TouchImageView pinch zoomed by user.
+            //
+            if (touchImageViewListener != null) {
+                touchImageViewListener.onMove();
+            }
             return true;
         }
         
         @Override
         public void onScaleEnd(ScaleGestureDetector detector) {
-        	super.onScaleEnd(detector);
-        	setState(State.NONE);
-        	boolean animateToZoomBoundary = false;
-        	float targetZoom = normalizedScale;
-        	if (normalizedScale > maxScale) {
-        		targetZoom = maxScale;
-        		animateToZoomBoundary = true;
-        		
-        	} else if (normalizedScale < minScale) {
-        		targetZoom = minScale;
-        		animateToZoomBoundary = true;
-        	}
-        	
-        	if (animateToZoomBoundary) {
-	        	DoubleTapZoom doubleTap = new DoubleTapZoom(targetZoom, viewWidth / 2, viewHeight / 2, true);
-	        	compatPostOnAnimation(doubleTap);
-        	}
+            super.onScaleEnd(detector);
+            setState(State.NONE);
+            boolean animateToZoomBoundary = false;
+            float targetZoom = normalizedScale;
+            if (normalizedScale > maxScale) {
+                targetZoom = maxScale;
+                animateToZoomBoundary = true;
+                
+            } else if (normalizedScale < minScale) {
+                targetZoom = minScale;
+                animateToZoomBoundary = true;
+            }
+            
+            if (animateToZoomBoundary) {
+                DoubleTapZoom doubleTap = new DoubleTapZoom(targetZoom, viewWidth / 2, viewHeight / 2, true);
+                compatPostOnAnimation(doubleTap);
+            }
         }
     }
     
     private void scaleImage(double deltaScale, float focusX, float focusY, boolean stretchImageToSuper) {
-    	float lowerScale, upperScale;
-    	if (stretchImageToSuper) {
-    		lowerScale = superMinScale;
-    		upperScale = superMaxScale;
-    		
-    	} else {
-    		lowerScale = minScale;
-    		upperScale = maxScale;
-    	}
-    	
-    	float origScale = normalizedScale;
+        float lowerScale, upperScale;
+        if (stretchImageToSuper) {
+            lowerScale = superMinScale;
+            upperScale = superMaxScale;
+            
+        } else {
+            lowerScale = minScale;
+            upperScale = maxScale;
+        }
+        
+        float origScale = normalizedScale;
         normalizedScale *= deltaScale;
         if (normalizedScale > upperScale) {
             normalizedScale = upperScale;
@@ -993,98 +992,98 @@ public class TouchImageView extends ImageView {
      *
      */
     private class DoubleTapZoom implements Runnable {
-    	
-    	private long startTime;
-    	private static final float ZOOM_TIME = 500;
-    	private float startZoom, targetZoom;
-    	private float bitmapX, bitmapY;
-    	private boolean stretchImageToSuper;
-    	private AccelerateDecelerateInterpolator interpolator = new AccelerateDecelerateInterpolator();
-    	private PointF startTouch;
-    	private PointF endTouch;
+        
+        private long startTime;
+        private static final float ZOOM_TIME = 500;
+        private float startZoom, targetZoom;
+        private float bitmapX, bitmapY;
+        private boolean stretchImageToSuper;
+        private AccelerateDecelerateInterpolator interpolator = new AccelerateDecelerateInterpolator();
+        private PointF startTouch;
+        private PointF endTouch;
 
-    	DoubleTapZoom(float targetZoom, float focusX, float focusY, boolean stretchImageToSuper) {
-    		setState(State.ANIMATE_ZOOM);
-    		startTime = System.currentTimeMillis();
-    		this.startZoom = normalizedScale;
-    		this.targetZoom = targetZoom;
-    		this.stretchImageToSuper = stretchImageToSuper;
-    		PointF bitmapPoint = transformCoordTouchToBitmap(focusX, focusY, false);
-    		this.bitmapX = bitmapPoint.x;
-    		this.bitmapY = bitmapPoint.y;
-    		
-    		//
-    		// Used for translating image during scaling
-    		//
-    		startTouch = transformCoordBitmapToTouch(bitmapX, bitmapY);
-    		endTouch = new PointF(viewWidth / 2, viewHeight / 2);
-    	}
+        DoubleTapZoom(float targetZoom, float focusX, float focusY, boolean stretchImageToSuper) {
+            setState(State.ANIMATE_ZOOM);
+            startTime = System.currentTimeMillis();
+            this.startZoom = normalizedScale;
+            this.targetZoom = targetZoom;
+            this.stretchImageToSuper = stretchImageToSuper;
+            PointF bitmapPoint = transformCoordTouchToBitmap(focusX, focusY, false);
+            this.bitmapX = bitmapPoint.x;
+            this.bitmapY = bitmapPoint.y;
+            
+            //
+            // Used for translating image during scaling
+            //
+            startTouch = transformCoordBitmapToTouch(bitmapX, bitmapY);
+            endTouch = new PointF(viewWidth / 2, viewHeight / 2);
+        }
 
-		@Override
-		public void run() {
-			float t = interpolate();
-			double deltaScale = calculateDeltaScale(t);
-			scaleImage(deltaScale, bitmapX, bitmapY, stretchImageToSuper);
-			translateImageToCenterTouchPosition(t);
-			fixScaleTrans();
-			setImageMatrix(matrix);
-			
-			//
-			// OnTouchImageViewListener is set: double tap runnable updates listener
-			// with every frame.
-			//
-			if (touchImageViewListener != null) {
-				touchImageViewListener.onMove();
-			}
-			
-			if (t < 1f) {
-				//
-				// We haven't finished zooming
-				//
-				compatPostOnAnimation(this);
-				
-			} else {
-				//
-				// Finished zooming
-				//
-				setState(State.NONE);
-			}
-		}
-		
-		/**
-		 * Interpolate between where the image should start and end in order to translate
-		 * the image so that the point that is touched is what ends up centered at the end
-		 * of the zoom.
-		 * @param t
-		 */
-		private void translateImageToCenterTouchPosition(float t) {
-			float targetX = startTouch.x + t * (endTouch.x - startTouch.x);
-			float targetY = startTouch.y + t * (endTouch.y - startTouch.y);
-			PointF curr = transformCoordBitmapToTouch(bitmapX, bitmapY);
-			matrix.postTranslate(targetX - curr.x, targetY - curr.y);
-		}
-		
-		/**
-		 * Use interpolator to get t
-		 * @return
-		 */
-		private float interpolate() {
-			long currTime = System.currentTimeMillis();
-			float elapsed = (currTime - startTime) / ZOOM_TIME;
-			elapsed = Math.min(1f, elapsed);
-			return interpolator.getInterpolation(elapsed);
-		}
-		
-		/**
-		 * Interpolate the current targeted zoom and get the delta
-		 * from the current zoom.
-		 * @param t
-		 * @return
-		 */
-		private double calculateDeltaScale(float t) {
-			double zoom = startZoom + t * (targetZoom - startZoom);
-			return zoom / normalizedScale;
-		}
+        @Override
+        public void run() {
+            float t = interpolate();
+            double deltaScale = calculateDeltaScale(t);
+            scaleImage(deltaScale, bitmapX, bitmapY, stretchImageToSuper);
+            translateImageToCenterTouchPosition(t);
+            fixScaleTrans();
+            setImageMatrix(matrix);
+            
+            //
+            // OnTouchImageViewListener is set: double tap runnable updates listener
+            // with every frame.
+            //
+            if (touchImageViewListener != null) {
+                touchImageViewListener.onMove();
+            }
+            
+            if (t < 1f) {
+                //
+                // We haven't finished zooming
+                //
+                compatPostOnAnimation(this);
+                
+            } else {
+                //
+                // Finished zooming
+                //
+                setState(State.NONE);
+            }
+        }
+        
+        /**
+         * Interpolate between where the image should start and end in order to translate
+         * the image so that the point that is touched is what ends up centered at the end
+         * of the zoom.
+         * @param t
+         */
+        private void translateImageToCenterTouchPosition(float t) {
+            float targetX = startTouch.x + t * (endTouch.x - startTouch.x);
+            float targetY = startTouch.y + t * (endTouch.y - startTouch.y);
+            PointF curr = transformCoordBitmapToTouch(bitmapX, bitmapY);
+            matrix.postTranslate(targetX - curr.x, targetY - curr.y);
+        }
+        
+        /**
+         * Use interpolator to get t
+         * @return
+         */
+        private float interpolate() {
+            long currTime = System.currentTimeMillis();
+            float elapsed = (currTime - startTime) / ZOOM_TIME;
+            elapsed = Math.min(1f, elapsed);
+            return interpolator.getInterpolation(elapsed);
+        }
+        
+        /**
+         * Interpolate the current targeted zoom and get the delta
+         * from the current zoom.
+         * @param t
+         * @return
+         */
+        private double calculateDeltaScale(float t) {
+            double zoom = startZoom + t * (targetZoom - startZoom);
+            return zoom / normalizedScale;
+        }
     }
     
     /**
@@ -1093,7 +1092,7 @@ public class TouchImageView extends ImageView {
      * @param x x-coordinate of touch event
      * @param y y-coordinate of touch event
      * @param clipToBitmap Touch event may occur within view, but outside image content. True, to clip return value
-     * 			to the bounds of the bitmap size.
+     *             to the bounds of the bitmap size.
      * @return Coordinates of the point touched, in the coordinate system of the original drawable.
      */
     private PointF transformCoordTouchToBitmap(float x, float y, boolean clipToBitmap) {
@@ -1106,8 +1105,8 @@ public class TouchImageView extends ImageView {
          float finalY = ((y - transY) * origH) / getImageHeight();
          
          if (clipToBitmap) {
-        	 finalX = Math.min(Math.max(finalX, 0), origW);
-        	 finalY = Math.min(Math.max(finalY, 0), origH);
+             finalX = Math.min(Math.max(finalX, 0), origW);
+             finalY = Math.min(Math.max(finalY, 0), origH);
          }
          
          return new PointF(finalX , finalY);
@@ -1139,149 +1138,149 @@ public class TouchImageView extends ImageView {
      *
      */
     private class Fling implements Runnable {
-    	
+        
         CompatScroller scroller;
-    	int currX, currY;
-    	
-    	Fling(int velocityX, int velocityY) {
-    		setState(State.FLING);
-    		scroller = new CompatScroller(context);
-    		matrix.getValues(m);
-    		
-    		int startX = (int) m[Matrix.MTRANS_X];
-    		int startY = (int) m[Matrix.MTRANS_Y];
-    		int minX, maxX, minY, maxY;
-    		
-    		if (getImageWidth() > viewWidth) {
-    			minX = viewWidth - (int) getImageWidth();
-    			maxX = 0;
-    			
-    		} else {
-    			minX = maxX = startX;
-    		}
-    		
-    		if (getImageHeight() > viewHeight) {
-    			minY = viewHeight - (int) getImageHeight();
-    			maxY = 0;
-    			
-    		} else {
-    			minY = maxY = startY;
-    		}
-    		
-    		scroller.fling(startX, startY, (int) velocityX, (int) velocityY, minX,
+        int currX, currY;
+        
+        Fling(int velocityX, int velocityY) {
+            setState(State.FLING);
+            scroller = new CompatScroller(context);
+            matrix.getValues(m);
+            
+            int startX = (int) m[Matrix.MTRANS_X];
+            int startY = (int) m[Matrix.MTRANS_Y];
+            int minX, maxX, minY, maxY;
+            
+            if (getImageWidth() > viewWidth) {
+                minX = viewWidth - (int) getImageWidth();
+                maxX = 0;
+                
+            } else {
+                minX = maxX = startX;
+            }
+            
+            if (getImageHeight() > viewHeight) {
+                minY = viewHeight - (int) getImageHeight();
+                maxY = 0;
+                
+            } else {
+                minY = maxY = startY;
+            }
+            
+            scroller.fling(startX, startY, (int) velocityX, (int) velocityY, minX,
                     maxX, minY, maxY);
-    		currX = startX;
-    		currY = startY;
-    	}
-    	
-    	public void cancelFling() {
-    		if (scroller != null) {
-    			setState(State.NONE);
-    			scroller.forceFinished(true);
-    		}
-    	}
-    	
-		@Override
-		public void run() {
-			
-			//
-			// OnTouchImageViewListener is set: TouchImageView listener has been flung by user.
-			// Listener runnable updated with each frame of fling animation.
-			//
-			if (touchImageViewListener != null) {
-				touchImageViewListener.onMove();
-			}
-			
-			if (scroller.isFinished()) {
-        		scroller = null;
-        		return;
-        	}
-			
-			if (scroller.computeScrollOffset()) {
-	        	int newX = scroller.getCurrX();
-	            int newY = scroller.getCurrY();
-	            int transX = newX - currX;
-	            int transY = newY - currY;
-	            currX = newX;
-	            currY = newY;
-	            matrix.postTranslate(transX, transY);
-	            fixTrans();
-	            setImageMatrix(matrix);
-	            compatPostOnAnimation(this);
-        	}
-		}
+            currX = startX;
+            currY = startY;
+        }
+        
+        public void cancelFling() {
+            if (scroller != null) {
+                setState(State.NONE);
+                scroller.forceFinished(true);
+            }
+        }
+        
+        @Override
+        public void run() {
+            
+            //
+            // OnTouchImageViewListener is set: TouchImageView listener has been flung by user.
+            // Listener runnable updated with each frame of fling animation.
+            //
+            if (touchImageViewListener != null) {
+                touchImageViewListener.onMove();
+            }
+            
+            if (scroller.isFinished()) {
+                scroller = null;
+                return;
+            }
+            
+            if (scroller.computeScrollOffset()) {
+                int newX = scroller.getCurrX();
+                int newY = scroller.getCurrY();
+                int transX = newX - currX;
+                int transY = newY - currY;
+                currX = newX;
+                currY = newY;
+                matrix.postTranslate(transX, transY);
+                fixTrans();
+                setImageMatrix(matrix);
+                compatPostOnAnimation(this);
+            }
+        }
     }
     
     @TargetApi(Build.VERSION_CODES.GINGERBREAD)
-	private class CompatScroller {
-    	Scroller scroller;
-    	OverScroller overScroller;
-    	boolean isPreGingerbread;
-    	
-    	public CompatScroller(Context context) {
-    		if (VERSION.SDK_INT < VERSION_CODES.GINGERBREAD) {
-    			isPreGingerbread = true;
-    			scroller = new Scroller(context);
-    			
-    		} else {
-    			isPreGingerbread = false;
-    			overScroller = new OverScroller(context);
-    		}
-    	}
-    	
-    	public void fling(int startX, int startY, int velocityX, int velocityY, int minX, int maxX, int minY, int maxY) {
-    		if (isPreGingerbread) {
-    			scroller.fling(startX, startY, velocityX, velocityY, minX, maxX, minY, maxY);
-    		} else {
-    			overScroller.fling(startX, startY, velocityX, velocityY, minX, maxX, minY, maxY);
-    		}
-    	}
-    	
-    	public void forceFinished(boolean finished) {
-    		if (isPreGingerbread) {
-    			scroller.forceFinished(finished);
-    		} else {
-    			overScroller.forceFinished(finished);
-    		}
-    	}
-    	
-    	public boolean isFinished() {
-    		if (isPreGingerbread) {
-    			return scroller.isFinished();
-    		} else {
-    			return overScroller.isFinished();
-    		}
-    	}
-    	
-    	public boolean computeScrollOffset() {
-    		if (isPreGingerbread) {
-    			return scroller.computeScrollOffset();
-    		} else {
-    			overScroller.computeScrollOffset();
-    			return overScroller.computeScrollOffset();
-    		}
-    	}
-    	
-    	public int getCurrX() {
-    		if (isPreGingerbread) {
-    			return scroller.getCurrX();
-    		} else {
-    			return overScroller.getCurrX();
-    		}
-    	}
-    	
-    	public int getCurrY() {
-    		if (isPreGingerbread) {
-    			return scroller.getCurrY();
-    		} else {
-    			return overScroller.getCurrY();
-    		}
-    	}
+    private class CompatScroller {
+        Scroller scroller;
+        OverScroller overScroller;
+        boolean isPreGingerbread;
+        
+        public CompatScroller(Context context) {
+            if (VERSION.SDK_INT < VERSION_CODES.GINGERBREAD) {
+                isPreGingerbread = true;
+                scroller = new Scroller(context);
+                
+            } else {
+                isPreGingerbread = false;
+                overScroller = new OverScroller(context);
+            }
+        }
+        
+        public void fling(int startX, int startY, int velocityX, int velocityY, int minX, int maxX, int minY, int maxY) {
+            if (isPreGingerbread) {
+                scroller.fling(startX, startY, velocityX, velocityY, minX, maxX, minY, maxY);
+            } else {
+                overScroller.fling(startX, startY, velocityX, velocityY, minX, maxX, minY, maxY);
+            }
+        }
+        
+        public void forceFinished(boolean finished) {
+            if (isPreGingerbread) {
+                scroller.forceFinished(finished);
+            } else {
+                overScroller.forceFinished(finished);
+            }
+        }
+        
+        public boolean isFinished() {
+            if (isPreGingerbread) {
+                return scroller.isFinished();
+            } else {
+                return overScroller.isFinished();
+            }
+        }
+        
+        public boolean computeScrollOffset() {
+            if (isPreGingerbread) {
+                return scroller.computeScrollOffset();
+            } else {
+                overScroller.computeScrollOffset();
+                return overScroller.computeScrollOffset();
+            }
+        }
+        
+        public int getCurrX() {
+            if (isPreGingerbread) {
+                return scroller.getCurrX();
+            } else {
+                return overScroller.getCurrX();
+            }
+        }
+        
+        public int getCurrY() {
+            if (isPreGingerbread) {
+                return scroller.getCurrY();
+            } else {
+                return overScroller.getCurrY();
+            }
+        }
     }
     
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
-	private void compatPostOnAnimation(Runnable runnable) {
-    	if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
+    private void compatPostOnAnimation(Runnable runnable) {
+        if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
             postOnAnimation(runnable);
             
         } else {
@@ -1290,22 +1289,22 @@ public class TouchImageView extends ImageView {
     }
     
     private class ZoomVariables {
-    	public float scale;
-    	public float focusX;
-    	public float focusY;
-    	public ScaleType scaleType;
-    	
-    	public ZoomVariables(float scale, float focusX, float focusY, ScaleType scaleType) {
-    		this.scale = scale;
-    		this.focusX = focusX;
-    		this.focusY = focusY;
-    		this.scaleType = scaleType;
-    	}
+        public float scale;
+        public float focusX;
+        public float focusY;
+        public ScaleType scaleType;
+        
+        public ZoomVariables(float scale, float focusX, float focusY, ScaleType scaleType) {
+            this.scale = scale;
+            this.focusX = focusX;
+            this.focusY = focusY;
+            this.scaleType = scaleType;
+        }
     }
     
     private void printMatrixInfo() {
-    	float[] n = new float[9];
-    	matrix.getValues(n);
-    	Log.d(DEBUG, "Scale: " + n[Matrix.MSCALE_X] + " TransX: " + n[Matrix.MTRANS_X] + " TransY: " + n[Matrix.MTRANS_Y]);
+        float[] n = new float[9];
+        matrix.getValues(n);
+        Log.d(DEBUG, "Scale: " + n[Matrix.MSCALE_X] + " TransX: " + n[Matrix.MTRANS_X] + " TransY: " + n[Matrix.MTRANS_Y]);
     }
 }


### PR DESCRIPTION
This converts all tabs in the main Java file to 4 spaces to have a consistent codestyle in viewers that use other tab width. Github for example shows spaces as 8 spaces.